### PR TITLE
iss27, 29

### DIFF
--- a/nestful/errors/error_generator.py
+++ b/nestful/errors/error_generator.py
@@ -1,6 +1,6 @@
 from nestful.utils import extract_label, TOKEN
 from nestful.schemas.errors import ErrorType
-from random import sample, randint
+from random import sample, randint, seed
 from typing import Optional, Dict, Any, Tuple, List, Set
 from copy import deepcopy
 from nestful.errors.error_tagger import tag_sequence_step, tag_sequence
@@ -22,7 +22,11 @@ def induce_error_in_step(
     error_type: ErrorType = ErrorType.UNKNOWN,
     num_errors: int = 1,
     referred_only: bool = True,
+    random_seed: Optional[int] = None,
 ) -> Tuple[Optional[SequenceStep], Dict[str, Any]]:
+    if random_seed:
+        seed(random_seed)
+
     if error_type == ErrorType.UNKNOWN:
         error_type = ErrorType.get_random_error()
 
@@ -61,9 +65,13 @@ def induce_error_in_sequence(
     error_type: ErrorType = ErrorType.UNKNOWN,
     num_errors: int = 1,
     referred_only: bool = True,
+    random_seed: Optional[int] = None,
 ) -> SequencingData:
     error_count = 0
     new_sequence = deepcopy(sequence)
+
+    if random_seed:
+        seed(random_seed)
 
     if error_type in [ErrorType.NEW_CALL, ErrorType.MADE_UP_API]:
         raise NotImplementedError(f"Error type {error_type} not supported yet.")
@@ -118,10 +126,14 @@ def batch_generate_error_steps(
     num_error_per_sample: int = 1,
     referred_only: bool = True,
     forbidden_indices: Optional[List[int]] = None,
+    random_seed: Optional[int] = None,
 ) -> List[AtomicCall]:
     current_samples: List[AtomicCall] = []
     stored_hashes = set()
     total_collisions = 0
+
+    if random_seed:
+        seed(random_seed)
 
     new_dataset = SequencingDataset(data=[])
 

--- a/nestful/errors/error_generator.py
+++ b/nestful/errors/error_generator.py
@@ -166,9 +166,14 @@ def batch_generate_error_steps(
 
                     current_samples.append(
                         AtomicCall(
+                            input=random_sequence.input,
                             call=error_step,
                             memory=new_memory,
-                            ground_truth=AtomicCall(call=step, memory=memory),
+                            ground_truth=AtomicCall(
+                                input=random_sequence.input,
+                                call=step,
+                                memory=memory,
+                            ),
                         )
                     )
 

--- a/nestful/schemas/sequences.py
+++ b/nestful/schemas/sequences.py
@@ -10,9 +10,14 @@ DUMMY_VALUE = "INIT"
 
 
 class AtomicCall(BaseModel):
+    input: str = ""
     call: SequenceStep
     memory: Dict[str, Any]
     ground_truth: Optional[AtomicCall] = None
+
+    @property
+    def sequence_form(self) -> SequencingData:
+        return SequencingData(input=self.input, output=[self.call])
 
 
 class SequenceStep(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nestful-wrapper"
-version = "0.0.6"
+version = "0.0.7"
 license = {file = "LICENSE"}
 authors = [
     { name = "Tathagata Chakraborti", email = "tchakra2@ibm.com" },

--- a/tests/errors/test_batch_generation.py
+++ b/tests/errors/test_batch_generation.py
@@ -1,7 +1,9 @@
 from nestful.data_handlers import get_nestful_data
 from nestful.errors import batch_generate_error_steps
 from nestful.schemas.errors import ErrorType
+from nestful import AtomicCall
 from random import randint
+from typing import List
 
 
 class TestBatchGeneration:
@@ -9,17 +11,28 @@ class TestBatchGeneration:
         self.sequence_data, self.catalog = get_nestful_data(executable=True)
 
     def test_batch_gen_sample_test(self) -> None:
+        previous_data: List[AtomicCall] = []
+
         for i in range(10):
             request_size = randint(1, i + 5)
-
             dataset = batch_generate_error_steps(
                 dataset=self.sequence_data,
                 catalog=self.catalog,
                 num_samples=request_size,
                 num_error_per_sample=1,
+                random_seed=16,
             )
 
             assert len(dataset) <= request_size
+
+            if previous_data:
+                same_length = min(len(previous_data), len(dataset))
+                assert (
+                    previous_data is None
+                    or previous_data[:same_length] == dataset[:same_length]
+                )
+
+            previous_data = dataset
 
     def test_batch_gen_step(self) -> None:
         dataset = batch_generate_error_steps(


### PR DESCRIPTION
@zdmwi the input is part of the returned call here. Before passing, check:

+ [x] #27 You are able to use the call as `call.sequence_form` directly for the prompt generator. 
+ [x] #27 The generated prompt contains the user input when fixing stuff (e.g. "query=" that requires extracting stuff from what the user said).
+ [x] #29 Check that the random seed propagates correctly across the entire generation (from batch to individual sequence to individual step), we don't want the seed to reset per call in batch generator.